### PR TITLE
jknepper/auto-cluster

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,11 +2,18 @@ default[:memsql][:owner] = 'memsql'
 default[:memsql][:group] = node.memsql.owner
 default[:memsql][:uid] = 2027
 default[:memsql][:gid] = node.memsql.uid
-default[:memsql][:license] = nil
+
+# Create the following data bags for use here:
+memsql_creds     = Chef::EncryptedDataBagItem.load("secrets", "memsql")
+datacrunch_creds = Chef::EncryptedDataBagItem.load("secrets", "datacrunch")
+developer_creds  = Chef::EncryptedDataBagItem.load("secrets", "developer")
+
+default[:memsql][:license] = "#{memsql_creds['license']}"
 default[:memsql][:version] = "3.1.x86_64.deb"
-default[:memsql][:redundancy_level] = 1
+default[:memsql][:redundancy_level] = 2
 default[:memsql][:url] = "http://download.memsql.com"
-default[:memsql][:users] = [{:name => 'developer', :password => 'password'}]
+
+default[:memsql][:users] = [{:name => "#{developer_creds['user']}", :password => "#{developer_creds['password']}"}, {:name => "#{datacrunch_creds['user']}", :password => "#{datacrunch_creds['password']}"}]
 default[:memsql][:node_scope][:enabled] = true
 default[:memsql][:node_scope][:filter] = " AND chef_environment:#{node.chef_environment}"
 default[:memsql][:mailto] = nil

--- a/files/default/memsql.cnf
+++ b/files/default/memsql.cnf
@@ -1,0 +1,31 @@
+; ------------------------------------------------------------------
+; THIS CONFIGURATION FILE IS MANAGED BY MEMSQL OPS
+; MemSQL Ops controls the data in this file.  Please be careful
+; when editing it.
+; For more information contact support@memsql.com
+; ------------------------------------------------------------------
+[server]
+basedir = .
+bind_address = 0.0.0.0
+core_file
+default_partitions_per_leaf = 4
+durability = on
+lc_messages_dir = ./share
+lock_wait_timeout = 60
+max_connections = 100000
+snapshot_trigger_size = 256m
+socket = memsql.sock
+tmpdir = .
+transaction_buffer = 64m
+; ------------------------------------------------------------------
+; MEMSQL OPS VARIABLES
+;
+; Variables below this header are controlled by MemSQL Ops.
+; Please do not edit any of these values directly.
+; ------------------------------------------------------------------
+master_aggregator
+port = 3306
+
+skip-name-resolve     = true
+master-aggregator
+redundancy_level = 2

--- a/memsql-testing.sh
+++ b/memsql-testing.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+export REGION='us-west-2'
+
+if [ "$REGION" == "us-east-1" ]; then
+    export env="prod"
+else
+    export env="qa"
+fi
+
+MEMSQL_PREFIX="${memsql:-memsql}"
+export MASTER_AGG_ROLE="${MEMSQL_PREFIX}_master_aggregator"
+export CHILD_AGG_ROLE="${MEMSQL_PREFIX}_child_aggregator"
+export LEAF_ROLE="${MEMSQL_PREFIX}_leaf"
+export LEAF_COUNT=${WORKER_COUNT:-2}
+export AZ=${MEMSQL_AZ:-${REGION}a}
+
+#master aggregators
+knife ec2 server create -r "role[${MASTER_AGG_ROLE}]" -i ~/.ssh/key-pair-2.pem -E ${env} -S key-pair-2 -N ${MASTER_AGG_ROLE//_/-}-01 -f r3.xlarge -g sg-c47151f7 -Z "$AZ" -I ami-5189a661
+
+#child aggregators
+knife ec2 server create -r "role[${CHILD_AGG_ROLE}]" -i ~/.ssh/key-pair-2.pem -E ${env} -S key-pair-2 -N ${CHILD_AGG_ROLE//_/-}-01 -f r3.xlarge -g sg-c47151f7 -Z "$AZ" -I ami-5189a661
+
+sleep 10
+
+knife ec2 server create -r "role[${CHILD_AGG_ROLE}]" -i ~/.ssh/key-pair-2.pem -E ${env} -S key-pair-2 -N ${CHILD_AGG_ROLE//_/-}-02 -f r3.xlarge -g sg-c47151f7 -Z "$AZ" -I ami-5189a661
+
+for (( c=1; c<=$LEAF_COUNT; c++ )); do
+  sleep 10
+  knife ec2 server create -r "role[${LEAF_ROLE}]" -i ~/.ssh/key-pair-2.pem -E ${env} -S key-pair-2 -N $(printf "%s%02d" "${LEAF_ROLE//_/-}"-0$c) -f r3.xlarge -g sg-c47151f7 -Z "$AZ" -I ami-5189a661
+done
+

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,13 +26,129 @@ if %x(grep #{node.memsql.owner} /etc/passwd | wc -l).strip.to_i == 0
   user node.memsql.owner do
     uid node.memsql.uid
     group node.memsql.group
+    home "/home/#{node.memsql.owner}/"
+    shell '/bin/bash'
   end
+
+  execute "add user to sudoers" do
+    command "/usr/sbin/adduser #{node.memsql.owner} sudo"
+    user 'root'
+    action :run
+    not_if "grep -Po '^sudo.+:\K.*$' /etc/group | grep memsql"
+  end
+
 end
 
 #TODO refactor
 filtered = node.memsql.node_scope.enabled ? node.memsql.node_scope.filter : ""
 mailto = node.memsql.mailto
-is_master = node.run_list.roles.include?("memsql_master_aggregator") ? true : false
+is_master      = node.run_list.roles.include?("memsql_master_aggregator") ? true : false
+is_child_agg   = node.run_list.roles.include?("memsql_child_aggregator") ? true : false
+is_leaf        = node.run_list.roles.include?("memsql_leaf") ? true : false
+
+#leaves     = search(:node, "role:memsql_leaf AND name:#{node['name']}-*")
+#child_aggs = search(:node, "role:memsql_child_aggregator AND name:#{node['name']}-*")
+
+memsql_keys = Chef::EncryptedDataBagItem.load( 'secrets', 'memsql_ssh' )
+memsql_lic  = Chef::EncryptedDataBagItem.load( 'secrets', 'memsql' )
+
+directory "/home/memsql" do
+  owner 'memsql'
+  group 'memsql'
+  mode '0700'
+  not_if { File.exists?("/home/#{node.memsql.owner}/") }
+end
+
+directory "/home/memsql/.ssh" do
+  owner 'memsql'
+  group 'memsql'
+  mode '0700'
+  not_if { File.exists?("/home/#{node.memsql.owner}/.ssh") }
+end
+
+
+cookbook_file '/opt/memsql-ops-4.0.32.tar.gz' do
+  source 'memsql-ops-4.0.32.tar.gz'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+execute 'memsql_untar' do
+  command 'tar xzvf /opt/memsql-ops-4.0.32.tar.gz'
+  cwd '/opt/'
+  action :run
+  not_if { File.exists?("/opt/memsql-ops-4.0.32") }
+end
+
+file '/opt/memsql-ops-4.0.32/' do
+  mode '0755'
+  user 'root'
+  group 'root'
+  action :create_if_missing
+end
+
+execute 'install_memsql' do
+  command './install.sh -n'
+  cwd '/opt/memsql-ops-4.0.32/'
+  user 'root'
+  group 'root'
+  action :run
+  not_if { File.exists?("/var/lib/memsql-ops") }
+end
+
+file "/home/memsql/.ssh/memsql" do
+  owner 'memsql'
+  group 'memsql'
+  mode '0600'
+  content memsql_keys['memsql_pem']
+end
+
+file "/home/memsql/.ssh/authorized_keys" do
+  owner 'memsql'
+  group 'memsql'
+  mode '644'
+  content memsql_keys['memsql_pub']
+end
+
+#find the master aggregator
+master_aggregator   = search(:node, "role:memsql_master_aggregator AND chef_environment:#{node.chef_environment}")
+master_ip_address   = ""
+
+if master_aggregator.length < 1 and is_master
+  master_ip_address = node.ipaddress
+else
+  master_ip_address = master_aggregator[0]['ipaddress']
+end
+
+# Install public keys into authorized_keys on leaf nodes to configure things
+# with the aggregator:
+if is_leaf == true or is_child_agg == true
+
+  execute 'deploy_to_hosts_in_cluster' do
+    command "/usr/bin/memsql-ops follow -h #{master_ip_address}"
+    user 'root'
+    group 'root'
+    ignore_failure true
+  end
+
+  if is_leaf == true 
+    execute 'deploy_memsql_node' do
+      command "/usr/bin/memsql-ops memsql-deploy --role leaf --license #{memsql_lic['license']}"
+      user 'memsql'
+      group 'memsql'
+      not_if "/usr/bin/memsql-ops memsql-list | grep #{node['ipaddress']}"
+    end
+  else
+    execute 'deploy_memsql_node' do
+      command "/usr/bin/memsql-ops memsql-deploy --role aggregator --license #{memsql_lic['license']}"
+      user 'memsql'
+      group 'memsql'
+      not_if "/usr/bin/memsql-ops memsql-list | grep #{node['ipaddress']}"
+    end
+  end
+end
 
 #install client libs
 if node.platform_family == 'debian'
@@ -45,38 +161,39 @@ end
   end
 end
 
-# remote_file "#{Chef::Config[:file_cache_path]}/memsql-#{node[:memsql][:version]}" do
-#   source "#{node[:memsql][:url]}/#{node[:memsql][:license]}/memsql-#{node[:memsql][:version]}"
-#   action :create_if_missing
-#   #notifies :install, "dpkg_package[memsql]", :immediately
-# end
+if is_master == true
 
-# dpkg_package "memsql" do
-#   source  "#{Chef::Config[:file_cache_path]}/memsql-#{node[:memsql][:version]}"
-#   action [:nothing]
-# end
+  remote_file '/opt/memsqlbin_amd64.tar.gz' do
+    source 'http://download.memsql.com/62c0f338a5ea4beea8c360cb215741ce/memsqlbin_amd64.tar.gz'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
 
-# #start memsql
-# service "memsql" do
-#   supports :status => true, :restart => true, :reload => true, :start => true, :stop => true
-#   action [:nothing]
-# end
+  execute 'add_memsql_to_primary_agent' do
+    command '/usr/bin/memsql-ops file-add -f -t memsql /opt/memsqlbin_amd64.tar.gz'
+    user 'root'
+    group 'root'
+    action :run
+  end
 
-#find the master aggregator
+  # Get private key onto master:
+  file "/home/memsql/.ssh/memsql" do
+    owner 'memsql'
+    group 'memsql'
+    mode '0600'
+    content memsql_keys['memsql_pem']
+  end
 
-master_aggregator = search(:node, "role:memsql_master_aggregator #{filtered}").first || node
+  execute 'deploy_memsql_node' do
+    command "/usr/bin/memsql-ops memsql-deploy --role master --license #{memsql_lic['license']}"
+    user 'root'
+    group 'root'
+    not_if "/usr/bin/memsql-ops memsql-list | grep #{node['ipaddress']}"
+  end
 
-#find leaf nodes
-leaves = search(:node, "role:memsql_leaf #{filtered}")
-
-#attaches leaf to master aggregator
-leaves.each do |node|
-  #Todo
-  #attach the leaf on the master aggregator
-  Chef::Log.info("leaf #{node["name"]} has IP address #{node["ipaddress"]}")
 end
-
-directory '/var/lib/memsql'
 
 template "/var/lib/memsql/memsql.cnf" do
   source "memsql.cnf.erb"
@@ -84,10 +201,22 @@ template "/var/lib/memsql/memsql.cnf" do
   owner "memsql"
   group "memsql"
   variables({
-                :master_aggregator_ip => node.run_list.roles.include?("memsql_child_aggregator") ? master_aggregator["ipaddress"] : nil,
-                :is_master => is_master,
-                :redundancy_level => node.memsql.redundancy_level
-            })
+    :master_aggregator_ip => node.run_list.roles.include?("memsql_child_aggregator") ? master_ip_address : nil,
+    :is_master => is_master,
+    :is_child_agg => is_child_agg,
+    :is_leaf => is_leaf,
+    :redundancy_level => node.memsql.redundancy_level
+  })
+end
+
+bash 'restart memsql' do
+  code <<-EOH
+    export id=`/usr/bin/memsql-ops memsql-list --local | /usr/bin/head -2 | /usr/bin/tail -1 | /usr/bin/perl -e 'while(<>) { $test = $_; $test =~ /([[a-zA-Z0-9]+)\s/g; print $1; }'`;
+    /usr/bin/memsql-ops memsql-restart $id
+  EOH
+
+  user 'root'
+  action :run
 end
 
 if is_master && node.memsql.bugs.broken_replication_in_31
@@ -109,8 +238,33 @@ if is_master && node.memsql.bugs.broken_replication_in_31
 
 end
 
-node[:memsql][:users].each do |user|
-  %x(sudo mysql -u root -h #{master_aggregator[:ipaddress]} -e "grant all on *.* to '#{user[:name]}'@'localhost' identified by '#{user[:password]}'; flush privileges;")
+
+if is_leaf or is_child_agg
+# 14 default[:memsql][:users] = [{:name 
+  execute 'add grants' do
+    command "/usr/bin/mysql -u root -h #{master_ip_address} -e \"grant all on *.* to '#{node[:memsql][:users][0][:name]}'@'localhost' identified by '#{node[:memsql][:users][0][:password]}'; flush privileges;\""
+    user 'root'
+    group 'root'
+  end
+
+  execute 'add grants' do
+    command "/usr/bin/mysql -u root -h #{master_ip_address} -e \"grant all on *.* to '#{node[:memsql][:users][1][:name]}'@'%' IDENTIFIED by '#{node[:memsql][:users][1][:password]}';\""
+    user 'root'
+    group 'root'
+  end
+  
+else is_master
+  execute 'add grants' do
+    command "/usr/bin/mysql -u root -h 0.0.0.0 -e \"grant all on *.* to '#{node[:memsql][:users][0][:name]}'@'localhost' identified by '#{node[:memsql][:users][0][:password]}'; flush privileges;\""
+    user 'root'
+    group 'root'
+  end
+
+  execute 'add grants' do
+    command "/usr/bin/mysql -u root -h 0.0.0.0 -e \"grant all on *.* to '#{node[:memsql][:users][1][:name]}'@'%' IDENTIFIED by '#{node[:memsql][:users][1][:password]}';\""
+    user 'root'
+    group 'root'
+  end
 end
 
 if node.memsql.ops.enabled

--- a/templates/default/memsql.cnf.erb
+++ b/templates/default/memsql.cnf.erb
@@ -34,6 +34,8 @@ max-connections     = 8192
 core-file
 critical-diagnostics  = off
 skip-name-resolve     = true
-<%= @is_master ? "master-aggregator" : "" %>
+<%= @is_master ? "master_aggregator" : "" %>
 <%= @is_master ? "redundancy_level = #{@redundancy_level}" : ""%>
-<%= !@master_aggregator_ip.nil? ? "master-aggregator = #{@master_aggregator_ip}" : ""%>
+
+<%= (!@is_master and !@is_leaf and @is_child_agg) ? "master_aggregator = #{@master_aggregator_ip}:3306" : ""%>
+


### PR DESCRIPTION
I used this to spin up a memsql cluster in AWS. 

This requires knife, chef, and all the configuration needed to run it with AWS.

Also, requires you create knife data bags for your memsql license, a private key named memsql (remember to sub newlins in your json uploaded to your chef server, etc), a developer user, and a datacrunch user.  If you look in the attributes/default.rb as well as the install.rb  you can see where it uses the data bags, and corresponding naming structure.  I used an encryption file too...

This will allow you to use the memsql_master_aggregator, memsql_child_aggregator, and memsql_leaf roles to create a functioning cluster.  The install.rb will find your master by region, and auto-add them all into the cluster... 

Lemme know if you have any more questions.  I tested it end-to-end.
